### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "engines": {
     "lens": "^6.0.0"
+    "freelens": "^1.0.0"
   },
   "main": "dist/main.js",
   "renderer": "dist/renderer.js",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "directory": "."
   },
   "engines": {
-    "lens": "^6.0.0"
+    "lens": "^6.0.0",
     "freelens": "^1.0.0"
   },
   "main": "dist/main.js",


### PR DESCRIPTION
Add freelens compatibility


Ex:
Installing lens-extension-0.2.4.tgz has failed, skipping. Reason: package.json must specify "freelens" in "engines" field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for Freelens runtime engine. The application now officially supports both Lens and Freelens runtimes, providing developers with multiple runtime environment options. This enhancement expands platform compatibility and deployment flexibility across different runtime configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->